### PR TITLE
Year rollover codebase maintenance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ License
     :alt: Licensed under the Apache License, Version 2.0
 
 The code and documentation of the Atlantis Command Processor project
-are copyright 2021 by Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO.
+are copyright 2021 – present by Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO.
 
 They are licensed under the Apache License, Version 2.0.
 https://www.apache.org/licenses/LICENSE-2.0

--- a/atlantis_cmd/__init__.py
+++ b/atlantis_cmd/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "21.1.dev0"
+__version__ = "22.1.dev0"

--- a/atlantis_cmd/__init__.py
+++ b/atlantis_cmd/__init__.py
@@ -1,4 +1,5 @@
-# Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO
+# Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+# The University of British Columbia, and CSIRO.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/atlantis_cmd/__init__.py
+++ b/atlantis_cmd/__init__.py
@@ -12,4 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 __version__ = "22.1.dev0"

--- a/atlantis_cmd/main.py
+++ b/atlantis_cmd/main.py
@@ -1,5 +1,5 @@
-#  Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia,
-#  and CSIRO.
+#  Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+#  The University of British Columbia, and CSIRO.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/atlantis_cmd/main.py
+++ b/atlantis_cmd/main.py
@@ -12,7 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """AtlantisCmd application
 
 Atlantis Ecosystem Model Command Processor

--- a/atlantis_cmd/run.py
+++ b/atlantis_cmd/run.py
@@ -1,5 +1,5 @@
-#  Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia,
-#  and CSIRO.
+#  Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+#  The University of British Columbia, and CSIRO.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/atlantis_cmd/run.py
+++ b/atlantis_cmd/run.py
@@ -12,7 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """AtlantisCmd command plug-in for run sub-command.
 
 Prepare for, execute, and gather the results of a run of the CSIRO Atlantis ecosystem model.

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -1,5 +1,5 @@
-#  Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia,
-#  and CSIRO.
+#  Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+#  The University of British Columbia, and CSIRO.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/cookiecutter/hooks/post_gen_project.py
+++ b/cookiecutter/hooks/post_gen_project.py
@@ -12,7 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Post-rendering script to set up symlinks and copied files in temporary run directory
 for a run of the CSIRO Atlantis ecosystem model.
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,22 +24,10 @@ setup_cfg = configparser.ConfigParser()
 setup_cfg.read(os.path.abspath("../setup.cfg"))
 project = setup_cfg["metadata"]["name"]
 
-author = "Doug Latornell"
-
-
-import datetime
+author = "the Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO"
 
 pkg_creation_year = 2021
-copyright_years = (
-    "{pkg_creation_year}".format(pkg_creation_year=pkg_creation_year)
-    if datetime.date.today().year == pkg_creation_year
-    else "{pkg_creation_year}-{today:%Y}".format(
-        pkg_creation_year=pkg_creation_year, today=datetime.date.today()
-    )
-)
-copyright = "{copyright_years}, {author}".format(
-    copyright_years=copyright_years, author=author
-)
+copyright = f"{pkg_creation_year}  – present by {author}"
 
 # The full version, including alpha/beta/rc tags
 import atlantis_cmd

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,9 +13,12 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
-*********************************************
+.. SPDX-License-Identifier: Apache-2.0
+
+
+*************************
 AtlantisCmd Documentation
-*********************************************
+*************************
 
 This is the documentation for the `AtlantisCmd`_ Python package.
 This package is developed and tested under Python 3.9.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors,
-.. The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ License
     :alt: Licensed under the Apache License, Version 2.0
 
 The code and documentation of the Atlantis Command Processor project
-are copyright 2021 by Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO.
+are copyright 2021 – present by the Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO.
 
 They are licensed under the Apache License, Version 2.0.
 https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/installation/atlantis_cmd.rst
+++ b/docs/installation/atlantis_cmd.rst
@@ -13,6 +13,9 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
+.. SPDX-License-Identifier: Apache-2.0
+
+
 .. _AtlantisCmdInstallation:
 
 ***************************************

--- a/docs/installation/atlantis_cmd.rst
+++ b/docs/installation/atlantis_cmd.rst
@@ -1,5 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors,
-.. The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -13,6 +13,9 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
+.. SPDX-License-Identifier: Apache-2.0
+
+
 ********************************************
 Conda Environment and Software Installations
 ********************************************

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,5 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors,
-.. The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -1,4 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.
@@ -423,7 +424,8 @@ License
     :alt: Licensed under the Apache License, Version 2.0
 
 The code and documentation of the Atlantis Command Processor project
-are copyright 2021 by Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO.
+are copyright 2021 – present by the Salish Sea Atlantis project contributors,
+The University of British Columbia, and CSIRO.
 
 They are licensed under the Apache License, Version 2.0.
 https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -13,6 +13,8 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
+.. SPDX-License-Identifier: Apache-2.0
+
 
 .. _AtlantisCmdPackagedDevelopment:
 

--- a/docs/run_description_file/index.rst
+++ b/docs/run_description_file/index.rst
@@ -13,6 +13,9 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
+.. SPDX-License-Identifier: Apache-2.0
+
+
 .. _RunDescriptionFileStructure:
 
 ******************************

--- a/docs/run_description_file/index.rst
+++ b/docs/run_description_file/index.rst
@@ -1,5 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors,
-.. The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/run_description_file/yaml_file.rst
+++ b/docs/run_description_file/yaml_file.rst
@@ -13,6 +13,9 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
+.. SPDX-License-Identifier: Apache-2.0
+
+
 .. _RunDescriptionFile:
 
 ********************

--- a/docs/run_description_file/yaml_file.rst
+++ b/docs/run_description_file/yaml_file.rst
@@ -1,5 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors,
-.. The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/docs/subcommands.rst
+++ b/docs/subcommands.rst
@@ -13,6 +13,8 @@
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
 
+.. SPDX-License-Identifier: Apache-2.0
+
 
 .. _AtlantisCmdSubcommands:
 

--- a/docs/subcommands.rst
+++ b/docs/subcommands.rst
@@ -1,5 +1,5 @@
-.. Copyright 2021, Salish Sea Atlantis project contributors,
-.. The University of British Columbia, and CSIRO
+.. Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+.. The University of British Columbia, and CSIRO.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+; SPDX-License-Identifier: Apache-2.0
+
+
 [metadata]
 name = AtlantisCmd
 version = attr: atlantis_cmd.__version__

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
-; Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO
+; Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+; The University of British Columbia, and CSIRO.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """AtlantisCmd - A command-line tool for doing various operations associated with the
 Salish Sea Atlantis project version of the CSIRO Atlantis ecosystem model.
 AtlantisCmd is based on, and provides Atlantis-specific extensions for

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-# Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO
+# Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+# The University of British Columbia, and CSIRO.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-#  Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia,
-#  and CSIRO.
+#  Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+#  The University of British Columbia, and CSIRO.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Shared fixtures for AtlantisCmd unit and integration tests.
 """
 import os

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -1,5 +1,5 @@
-#  Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia,
-#  and CSIRO.
+#  Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+#  The University of British Columbia, and CSIRO.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -12,7 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Functional tests for symlinks and file copies created by cookiecutter
 post_gen_project hook script.
 """

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,6 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """AtlantisCmd run sub-command plug-in unit and integration tests.
 """
 import logging

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,5 +1,5 @@
-# Copyright 2021, Salish Sea Atlantis project contributors, The University of British Columbia,
-# and CSIRO.
+#  Copyright 2021 – present by the Salish Sea Atlantis project contributors,
+#  The University of British Columbia, and CSIRO.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Bump version to 22.1.dev0
* Make end of copyright year range "present" so that it never has to be updated again :-)
* Add SPDX license identifiers