### PR TITLE
Update to Python 3.12

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -3,6 +3,9 @@ name: pytest-with-coverage
 on:
   push:
     branches: [ '*' ]
+  # Enable workflow to be triggered from GitHub CLI, browser, or via API
+  # primarily for testing conda env solution for new Python versions
+  workflow_dispatch:
 
 jobs:
   pytest-with-coverage:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.11', '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/pytest-with-coverage.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -83,7 +83,7 @@ tomli==2.0.1
 typing_extensions==4.7.1
 ukkonen==1.0.1
 Unidecode==1.3.6
-urllib3==2.0.6
+urllib3==2.0.7
 virtualenv==20.24.3
 wcwidth==0.2.6
 wheel==0.41.2


### PR DESCRIPTION
- [x] Add Python 3.12 to GHA pytest-with-coverage workflow so that we can use the workflow to test whether all the packages NEMO-Cmd depends on have been updated to support Python 3.12.
- [x] Add `workflow_dispatch` trigger to GHA pytest-with-coverage workflow to enable workflow to be triggered from
GitHub CLI, browser or via API
- [ ] Change sphinx-linkcheck workflow to Python 3.12
- [ ] Change to Python 3.12 for package development