### PR TITLE
Move coverage configuration to pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-branch = True
-source =
-    atlantis_cmd
-    tests
-
-[report]
-show_missing = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,14 @@ gather = "nemo_cmd.gather:Gather"
 run = "atlantis_cmd.run:Run"
 
 
+[tool.coverage.run]
+branch = true
+source = ["atlantis_cmd", "tests"]
+
+[tool.coverage.report]
+show_missing = true
+
+
 [tool.hatch.build.targets.wheel]
 packages = ["atlantis_cmd"]
 


### PR DESCRIPTION
The configuration for coverage has been relocated from .coveragerc to pyproject.toml. This change consolidates project settings into a single file, simplifying configuration management. Additionally, it aligns with modern Python project best practices.