### PR TITLE
Add GitHub Actions workflow to auto-assign milestones to issues/PRs

### DIFF
--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -1,0 +1,18 @@
+name: Add Milestone to Issue/PR
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  add_milestone:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main


### PR DESCRIPTION
Introduces a workflow to automatically assign the current milestone to newly opened issues and pull requests targeting the main branch. This improves workflow automation and ensures consistent milestone tracking. Leverages a reusable workflow from UBC-MOAD.